### PR TITLE
Switch documentation for variables from comments to description fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ A part of this README is generated using [Terraform-docs](https://github.com/seg
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| env\_name | Name our environment. Used for tagging in AWS | string | n/a | yes |
-| vpc\_cidr\_second\_octet |  | string | `"0"` | no |
-| vpc\_data\_subnet\_prefix |  | string | `"3"` | no |
-| vpc\_private\_subnet\_prefix |  | string | `"2"` | no |
-| vpc\_public\_subnet\_prefix |  | string | `"1"` | no |
-| zone\_count | Amount of AWS zones we want to use for this VPC | string | `"1"` | no |
+| env\_name | Name for the environment you are creating (e.g. 'lab' or 'prod'). Used for tagging in AWS | string | n/a | yes |
+| vpc\_cidr\_second\_octet | Second octet of the CIDR block for the VPC (10.x.0.0/16) | string | `"0"` | no |
+| vpc\_data\_subnet\_prefix | Prefix for data subnets, used in the 3rd octet (10.0.xx.0/24) | string | `"3"` | no |
+| vpc\_private\_subnet\_prefix | Prefix for private subnets, used in the 3rd octet (10.0.xx.0/24) | string | `"2"` | no |
+| vpc\_public\_subnet\_prefix | Prefix for public subnets, used in the 3rd octet (10.0.xx.0/24) | string | `"1"` | no |
+| zone\_count | Amount of Availability Zones (AZs) we want to use | string | `"1"` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,15 @@
-# Name our environment. Used for tagging in AWS
-variable "env_name" {}
-
-# Amount of AWS zones we want to use for this VPC
-variable "zone_count" {
-  default = 1
-}
-
-# Get current AWS region
 data "aws_region" "current" {}
 
-# Get available AZs from AWS
 data "aws_availability_zones" "available" {}
+
+variable "env_name" {
+  description = "Name for the environment you are creating (e.g. 'lab' or 'prod'). Used for tagging in AWS"
+}
+
+variable "zone_count" {
+  description = "Amount of Availability Zones (AZs) we want to use"
+  default     = 1
+}
 
 #
 # Our VPC network is configured as follows:
@@ -25,17 +24,21 @@ data "aws_availability_zones" "available" {}
 #
 
 variable vpc_cidr_second_octet {
-  default = 0
+  description = "Second octet of the CIDR block for the VPC (10.x.0.0/16)"
+  default     = 0
 }
 
 variable vpc_public_subnet_prefix {
-  default = 1
+  description = "Prefix for public subnets, used in the 3rd octet (10.0.xx.0/24)"
+  default     = 1
 }
 
 variable vpc_private_subnet_prefix {
-  default = 2
+  description = "Prefix for private subnets, used in the 3rd octet (10.0.xx.0/24)"
+  default     = 2
 }
 
 variable vpc_data_subnet_prefix {
-  default = 3
+  description = "Prefix for data subnets, used in the 3rd octet (10.0.xx.0/24)"
+  default     = 3
 }


### PR DESCRIPTION
This switch ensures compatibility with both terraform-docs (for generating part of the README) as the Terraform Module Registry, that takes the description lines to generate similar docs