### PR TITLE
use cidrsubnet interpolation to generate subnets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+---
+default_stages: [commit]
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+    - id: trailing-whitespace
+      args: [--markdown-linebreak-ext=md]
+    - id: check-yaml
+  - repo: local
+    hooks:
+    - id: generate-readme
+      name: Generate Terraform Docs in README
+      entry: ./generate-readme
+      language: script
+      files: ^.*\.tf$

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ A part of this README is generated using [Terraform-docs](https://github.com/seg
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | env\_name | Name for the environment you are creating (e.g. 'lab' or 'prod'). Used for tagging in AWS | string | n/a | yes |
-| vpc\_cidr\_second\_octet | Second octet of the CIDR block for the VPC (10.x.0.0/16) | string | `"0"` | no |
-| vpc\_data\_subnet\_prefix | Prefix for data subnets, used in the 3rd octet (10.0.xx.0/24) | string | `"3"` | no |
-| vpc\_private\_subnet\_prefix | Prefix for private subnets, used in the 3rd octet (10.0.xx.0/24) | string | `"2"` | no |
-| vpc\_public\_subnet\_prefix | Prefix for public subnets, used in the 3rd octet (10.0.xx.0/24) | string | `"1"` | no |
+| vpc\_cidr | Base CIDR block for the VPC supernet | string | `"10.0.0.0/16"` | no |
+| vpc\_data\_subnet\_offset | Offset for calculating data subnets. (10.0.x.0/24) | string | `"201"` | no |
+| vpc\_private\_subnet\_offset | Offset for calculating private subnets. (10.0.x.0/24) | string | `"101"` | no |
+| vpc\_public\_subnet\_offset | Offset for calculating public subnets. (10.0.x.0/24) | string | `"1"` | no |
 | zone\_count | Amount of Availability Zones (AZs) we want to use | string | `"1"` | no |
 
 ## Outputs

--- a/examples/advanced-implementation/main.tf
+++ b/examples/advanced-implementation/main.tf
@@ -8,10 +8,10 @@ module "vpc" {
 
   zone_count                = 3
   env_name                  = "aws-vpc-advanced-example"
-  vpc_cidr_second_octet     = 12
-  vpc_public_subnet_prefix  = 4
-  vpc_private_subnet_prefix = 5
-  vpc_data_subnet_prefix    = 6
+  vpc_cidr                  = "10.1.0.0/16"
+  vpc_public_subnet_offset  = 1
+  vpc_private_subnet_offset = 11
+  vpc_data_subnet_offset    = 21
 }
 
 # Take the outputs from the module and directly map them to plan outputs

--- a/main.tf
+++ b/main.tf
@@ -14,9 +14,9 @@ resource "aws_subnet" "public" {
   count = "${var.zone_count}"
 
   vpc_id                  = "${aws_vpc.default.id}"
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
   cidr_block              = "${cidrsubnet(var.vpc_cidr, 8, count.index + var.vpc_public_subnet_offset)}"
   map_public_ip_on_launch = "true"
-  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags = {
     Name = "${var.env_name}-vpc public network ${element(data.aws_availability_zones.available.names, count.index)}"
@@ -28,9 +28,9 @@ resource "aws_subnet" "private" {
   count = "${var.zone_count}"
 
   vpc_id                  = "${aws_vpc.default.id}"
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
   cidr_block              = "${cidrsubnet(var.vpc_cidr, 8, count.index + var.vpc_private_subnet_offset)}"
   map_public_ip_on_launch = "false"
-  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags = {
     Name = "${var.env_name}-vpc private network ${element(data.aws_availability_zones.available.names, count.index)}"
@@ -42,9 +42,9 @@ resource "aws_subnet" "data" {
   count = "${var.zone_count}"
 
   vpc_id                  = "${aws_vpc.default.id}"
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
   cidr_block              = "${cidrsubnet(var.vpc_cidr, 8, count.index + var.vpc_data_subnet_offset)}"
   map_public_ip_on_launch = "false"
-  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
   tags = {
     Name = "${var.env_name}-vpc data network ${element(data.aws_availability_zones.available.names, count.index)}"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 # VPC
 resource "aws_vpc" "default" {
-  cidr_block           = "10.${var.vpc_cidr_second_octet}.0.0/16"
+  cidr_block           = "${var.vpc_cidr}"
   enable_dns_support   = "true"
   enable_dns_hostnames = "true"
 
@@ -14,7 +14,7 @@ resource "aws_subnet" "public" {
   count = "${var.zone_count}"
 
   vpc_id                  = "${aws_vpc.default.id}"
-  cidr_block              = "10.${var.vpc_cidr_second_octet}.${var.vpc_public_subnet_prefix}${count.index +1}.0/24"
+  cidr_block              = "${cidrsubnet(var.vpc_cidr, 8, count.index + var.vpc_public_subnet_offset)}"
   map_public_ip_on_launch = "true"
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
@@ -28,7 +28,7 @@ resource "aws_subnet" "private" {
   count = "${var.zone_count}"
 
   vpc_id                  = "${aws_vpc.default.id}"
-  cidr_block              = "10.${var.vpc_cidr_second_octet}.${var.vpc_private_subnet_prefix}${count.index +1}.0/24"
+  cidr_block              = "${cidrsubnet(var.vpc_cidr, 8, count.index + var.vpc_private_subnet_offset)}"
   map_public_ip_on_launch = "false"
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 
@@ -42,7 +42,7 @@ resource "aws_subnet" "data" {
   count = "${var.zone_count}"
 
   vpc_id                  = "${aws_vpc.default.id}"
-  cidr_block              = "10.${var.vpc_cidr_second_octet}.${var.vpc_data_subnet_prefix}${count.index +1}.0/24"
+  cidr_block              = "${cidrsubnet(var.vpc_cidr, 8, count.index + var.vpc_data_subnet_offset)}"
   map_public_ip_on_launch = "false"
   availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,27 +18,27 @@ variable "zone_count" {
 # - the second octet is zero by default but can be changed
 # - we can identify public, private, and data subnets (classic 3-tier setup)
 # - each subnet is assigned a /24 block
-# - the third octet is built out of a prefix, indicating the type of subnet, and a counter
+# - we use offsets (1/101/201) as a base for calculating subnets.
 #
-# As a result, using the default values, the CIDR of the second private subnet would be 10.0.22.0/24
+# As a result, using the default values, the CIDR of the second private subnet would be 10.0.102.0/24
 #
 
-variable vpc_cidr_second_octet {
-  description = "Second octet of the CIDR block for the VPC (10.x.0.0/16)"
-  default     = 0
+variable "vpc_cidr" {
+  description = "Base CIDR block for the VPC supernet"
+  default     = "10.0.0.0/16"
 }
 
-variable vpc_public_subnet_prefix {
-  description = "Prefix for public subnets, used in the 3rd octet (10.0.xx.0/24)"
+variable vpc_public_subnet_offset {
+  description = "Offset for calculating public subnets. (10.0.x.0/24)"
   default     = 1
 }
 
-variable vpc_private_subnet_prefix {
-  description = "Prefix for private subnets, used in the 3rd octet (10.0.xx.0/24)"
-  default     = 2
+variable vpc_private_subnet_offset {
+  description = "Offset for calculating private subnets. (10.0.x.0/24)"
+  default     = 101
 }
 
-variable vpc_data_subnet_prefix {
-  description = "Prefix for data subnets, used in the 3rd octet (10.0.xx.0/24)"
-  default     = 3
+variable vpc_data_subnet_offset {
+  description = "Offset for calculating data subnets. (10.0.x.0/24)"
+  default     = 201
 }


### PR DESCRIPTION
Instead of using formatting tricks to create each subnet's cidr block, just provide a base CIDR and let it generate.